### PR TITLE
vite: scope dep-optimizer scan to the app entry (not test HTML)

### DIFF
--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -45,6 +45,11 @@ export function ember(params?: {
         config.optimizeDeps.exclude ||= [];
         config.optimizeDeps.extensions ||= [];
 
+        // Pin the dep-optimizer scan to the app entry. With optimizeDeps.entries
+        // unset, Vite defaults to scanning **/*.html — it ignores __tests__/ and
+        // coverage/, but NOT Ember's tests/index.html. Overridable.
+        config.optimizeDeps.entries ??= ['index.html'];
+
         if (!config.resolve.extensions) {
           config.resolve.extensions = extensions;
         }

--- a/packages/vite/tests/optimize-deps-entries.test.js
+++ b/packages/vite/tests/optimize-deps-entries.test.js
@@ -1,0 +1,50 @@
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import { it, expect, describe, vi } from 'vitest';
+
+// `resolver()` builds a ResolverLoader(process.cwd()), which requires a real
+// embroider app at cwd. We only need the `vite-plugin-ember-config` plugin from
+// ember(), so stub the resolver plugin out.
+vi.mock('../src/resolver', () => ({ resolver: () => ({ name: 'stub-resolver' }) }));
+
+import { ember } from '../src/ember';
+
+// Regression test: ember() defaults optimizeDeps.entries to the app entry, so a
+// bad import in a test file can't abort the scan and disable app pre-bundling.
+
+function getConfigHook() {
+  const plugin = ember().find(
+    p => p && typeof p === 'object' && 'name' in p && p.name === 'vite-plugin-ember-config'
+  );
+  if (!plugin || typeof plugin.config !== 'function') {
+    throw new Error('vite-plugin-ember-config config hook not found');
+  }
+  return plugin.config.bind(plugin);
+}
+
+// The hook mutates `config` in place and sets entries before its later
+// rolldown/esbuild wiring (which needs a full Vite context); ignore a late throw.
+async function runConfigHook(userConfig) {
+  const hook = getConfigHook();
+  const env = { command: 'serve', mode: 'development' };
+  try {
+    await hook.call({}, userConfig, env);
+  } catch {
+    // ignore – the entries default is applied before any throw
+  }
+  return userConfig;
+}
+
+describe('ember() optimizeDeps.entries', () => {
+  it('defaults the dependency-optimizer scan to the app entry (not test HTML)', async () => {
+    const config = await runConfigHook({ plugins: [] });
+    expect(config.optimizeDeps?.entries).toEqual(['index.html']);
+  });
+
+  it('does not override an explicit optimizeDeps.entries', async () => {
+    const config = await runConfigHook({
+      plugins: [],
+      optimizeDeps: { entries: ['index.html', 'app/**/*.{ts,js,gts,gjs}'] },
+    });
+    expect(config.optimizeDeps?.entries).toEqual(['index.html', 'app/**/*.{ts,js,gts,gjs}']);
+  });
+});


### PR DESCRIPTION
## Problem

When `optimizeDeps.entries` is unset, **Vite** defaults to scanning `**/*.html` for the dependency optimizer. It ignores `**/__tests__/**` and `**/coverage/**` — but **not** Ember's `tests/index.html`, which `import.meta.glob`s every test module into the graph. Embroider sets no `entries`, so this default applies.

The result: a single unresolvable import in **any** (even unrun) test file aborts the whole scan:

```
(!) Failed to run dependency scan. Skipping dependency pre-bundling.
```

The app then gets **no** pre-bundled deps → a cascade of runtime `new dependencies optimized … reloading` on cold start. The only clue is one buried startup warning about a test file, which is hard to connect to the symptom (easy to hit via a half-removed addon leaving a dangling test/`_app_` import).

Repro: https://github.com/johanrd/embroider-repro-optimize-deps/tree/repro/scan-skip-tests

## Fix (this PR = option A)

Default `optimizeDeps.entries` to `['index.html']` so the dev-server scan covers the app only. It's only set when unset, so apps can still override it.

```js
config.optimizeDeps.entries ??= ['index.html'];
```

## Options considered

| | Status quo (no change) | **A — `['index.html']` (this PR)** | B — hard-coded extension |
|---|---|---|---|
| Config | *none: i.e. [Vite default](http://vite.dev/config/dep-optimization-options#optimizedeps-entries): `**/*.html, '**/*.html', '!**/__tests__/**', '!**/coverage/**'`* | `['index.html']` | `['**/*.html', '!**/__tests__/**', '!**/coverage/**', '!tests/index.html']` |
| Fixes the bug | ❌ one bad test import disables app pre-bundling | ✅ | ✅ |
| `pnpm start` startup | scans + pre-bundles test-only deps too | ✅ faster — app deps only | ✅ faster — app deps only |
| Multi-`.html`-entry apps | ✅ all scanned | ⚠️ only `index.html` scanned (rare in Ember SPAs) | ✅ preserved |
| Test-only deps | pre-bundled up front | lazy on first `/tests` visit | lazy on first `/tests` visit |
| Maintenance | n/a | ✅ drift-proof (no Vite internals copied) | ❌ brittle — duplicates Vite's default glob + ignore list; drifts if Vite changes them¹ |

¹ Setting `entries` is all-or-nothing: it replaces Vite's default **and** drops Vite's `__tests__`/`coverage` auto-ignore, so B must re-declare those — a copy of Vite internals that can silently break on a Vite minor.

I went with **A**: simplest, drift-proof, and behaviorally identical to B for a normal app (just `index.html` + `tests/index.html`). Happy to switch to B if multi-entry support is a goal.

## Notes

- The deeper "abort all pre-bundling on one failed module" is **Vite core** — this PR only shrinks the blast radius from "any `.html` (incl. tests)" to "the app entry". A zero-behavior-change alternative would be to make embroider's scan resolver not *abort* on an unresolvable import (preserves test scanning, but more involved and changes error semantics).
- Whether the dev scan should include test HTML by default is a policy call — flagging for maintainer input.
- Adds a regression test; full `@embroider/vite` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
